### PR TITLE
Improve Duke to allow mass Done and Delete operations.

### DIFF
--- a/src/main/java/fan/cs2103t/duke/command/DeleteCommand.java
+++ b/src/main/java/fan/cs2103t/duke/command/DeleteCommand.java
@@ -1,7 +1,11 @@
 package fan.cs2103t.duke.command;
 
 import static fan.cs2103t.duke.commons.Messages.MESSAGE_SUCCESSFULLY_DELETED_FORMAT;
-import static fan.cs2103t.duke.commons.Messages.MESSAGE_TASK_NOT_FOUND;
+import static fan.cs2103t.duke.commons.Messages.MESSAGE_TASK_NOT_FOUND_FORMAT;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 
 import fan.cs2103t.duke.task.Task;
 import fan.cs2103t.duke.task.TaskList;
@@ -14,44 +18,57 @@ import fan.cs2103t.duke.ui.Ui;
  */
 public class DeleteCommand extends Command {
 
-    private final int taskIndex;
+    private final ArrayList<Integer> indicesOfTasks;
 
     /**
-     * Constructs a delete command with the specified index of the task to be deleted from Duke's task list.
+     * Constructs a delete command with the specified list of indices of all the tasks
+     * to be deleted from Duke's task list.
      *
-     * @param taskIndex the index of the task to be deleted.
+     * @param indicesOfTasks the list of indices of all the tasks to be deleted.
      */
-    public DeleteCommand(int taskIndex) {
-        this.taskIndex = taskIndex;
+    public DeleteCommand(ArrayList<Integer> indicesOfTasks) {
+        assert indicesOfTasks.size() >= 1;
+        this.indicesOfTasks = indicesOfTasks;
     }
 
     /**
-     * Executes this command. Deletes the task with the index from the specified task list.
-     * Displays a message to the user through the specified UI if the task is successfully deleted,
-     * or exits the current program immediately if the process fails.
+     * Executes this command. Deletes tasks with index inside <code>indicesOfTasks</code> from the specified task list.
+     * Displays a message to the user through the specified UI to show the execution status for each task:
+     * if the task is successfully deleted. The current program is exited immediately if any deletion fails.
      * Returns the status message as a string.
      *
-     * @param taskList the task list for the task to be deleted from.
+     * @param taskList the task list for tasks to be deleted from.
      * @param ui the UI for the message to be displayed through.
      * @return a message to indicate the status of execution.
      */
     @Override
     public String execute(TaskList taskList, Ui ui) {
-        String output = null;
-        try {
-            Task t = taskList.getTasks().get(taskIndex - 1);
-            String description = t.getDescriptionWithStatus();
-            if (taskList.deleteTask(taskIndex - 1)) {
-                output = String.format(MESSAGE_SUCCESSFULLY_DELETED_FORMAT, description, taskList.getNumOfTasks());
-                ui.displayText(output);
-            } else {
-                System.exit(1);
+        processIndices(); // remove all duplicate indices and sort by value
+        StringBuilder output = new StringBuilder();
+        for (int i = indicesOfTasks.size() - 1; i >= 0; i--) {
+            Integer taskIndex = indicesOfTasks.get(i);
+            try {
+                Task t = taskList.getTasks().get(taskIndex - 1);
+                String description = t.getDescriptionWithStatus();
+                if (taskList.deleteTask(taskIndex - 1)) {
+                    output.insert(0, String.format(MESSAGE_SUCCESSFULLY_DELETED_FORMAT, taskIndex, description));
+                } else {
+                    System.exit(1);
+                }
+            } catch (IndexOutOfBoundsException ex) {
+                output.insert(0, String.format(MESSAGE_TASK_NOT_FOUND_FORMAT, taskIndex));
             }
-        } catch (IndexOutOfBoundsException ex) {
-            output = MESSAGE_TASK_NOT_FOUND;
-            ui.displayText(output);
         }
-        return output;
+        output.setLength(output.length() - 1);
+        ui.displayText(output.toString());
+        return output.toString();
+    }
+
+    private void processIndices() {
+        HashSet<Integer> set = new HashSet<>(indicesOfTasks);
+        indicesOfTasks.clear();
+        indicesOfTasks.addAll(set);
+        Collections.sort(indicesOfTasks);
     }
 
 }

--- a/src/main/java/fan/cs2103t/duke/command/DoneCommand.java
+++ b/src/main/java/fan/cs2103t/duke/command/DoneCommand.java
@@ -1,8 +1,12 @@
 package fan.cs2103t.duke.command;
 
 import static fan.cs2103t.duke.commons.Messages.MESSAGE_SUCCESSFULLY_DONE_FORMAT;
-import static fan.cs2103t.duke.commons.Messages.MESSAGE_TASK_ALREADY_DONE;
-import static fan.cs2103t.duke.commons.Messages.MESSAGE_TASK_NOT_FOUND;
+import static fan.cs2103t.duke.commons.Messages.MESSAGE_TASK_ALREADY_DONE_FORMAT;
+import static fan.cs2103t.duke.commons.Messages.MESSAGE_TASK_NOT_FOUND_FORMAT;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 
 import fan.cs2103t.duke.task.Task;
 import fan.cs2103t.duke.task.TaskList;
@@ -15,45 +19,58 @@ import fan.cs2103t.duke.ui.Ui;
  */
 public class DoneCommand extends Command {
 
-    private final int taskIndex;
+    private final ArrayList<Integer> indicesOfTasks;
 
     /**
-     * Constructs a done command with the specified index of the task to be marked as done.
+     * Constructs a done command with the specified list of indices of all the tasks to be marked as done.
      *
-     * @param taskIndex the index of the task to be marked as done.
+     * @param indicesOfTasks the list of indices of all the tasks to be marked as done.
      */
-    public DoneCommand(int taskIndex) {
-        this.taskIndex = taskIndex;
+    public DoneCommand(ArrayList<Integer> indicesOfTasks) {
+        assert indicesOfTasks.size() >= 1;
+        this.indicesOfTasks = indicesOfTasks;
     }
 
     /**
-     * Executes this command. Changes the completion status of the task with the index to "done".
-     * Displays a message to the user through the specified UI if the status of the task is successfully changed,
-     * or the task has already been marked as done, or the task with the index does not exist.
+     * Executes this command. Changes the completion status of tasks with index
+     * inside <code>indicesOfTasks</code> to "done".
+     * Displays a message to the user through the specified UI to show the execution status for each task:
+     * if the status of the task is successfully changed,
+     * or the task has already been marked as done, or the task with an index does not exist.
      * Returns the status message as a string.
      *
-     * @param taskList the task list that the task to be marked as done is in.
+     * @param taskList the task list that tasks to be marked as done are in.
      * @param ui the UI for the message to be displayed through.
      * @return a message to indicate the status of execution.
      */
     @Override
     public String execute(TaskList taskList, Ui ui) {
-        String output;
-        try {
-            Task t = taskList.getTasks().get(taskIndex - 1);
-            if (t.getIsDone()) {
-                output = MESSAGE_TASK_ALREADY_DONE;
-                ui.displayText(output);
-            } else {
-                t.markAsDone();
-                output = String.format(MESSAGE_SUCCESSFULLY_DONE_FORMAT, t.getDescriptionWithStatus());
-                ui.displayText(output);
+        processIndices(); // remove all duplicate indices and sort by value
+        StringBuilder output = new StringBuilder();
+        for (Integer taskIndex : indicesOfTasks) {
+            try {
+                Task t = taskList.getTasks().get(taskIndex - 1);
+                if (t.getIsDone()) {
+                    output.append(String.format(MESSAGE_TASK_ALREADY_DONE_FORMAT, taskIndex));
+                } else {
+                    t.markAsDone();
+                    output.append(String.format(MESSAGE_SUCCESSFULLY_DONE_FORMAT,
+                            taskIndex, t.getDescriptionWithStatus()));
+                }
+            } catch (IndexOutOfBoundsException ex) {
+                output.append(String.format(MESSAGE_TASK_NOT_FOUND_FORMAT, taskIndex));
             }
-        } catch (IndexOutOfBoundsException ex) {
-            output = MESSAGE_TASK_NOT_FOUND;
-            ui.displayText(output);
         }
-        return output;
+        output.setLength(output.length() - 1);
+        ui.displayText(output.toString());
+        return output.toString();
+    }
+
+    private void processIndices() {
+        HashSet<Integer> set = new HashSet<>(indicesOfTasks);
+        indicesOfTasks.clear();
+        indicesOfTasks.addAll(set);
+        Collections.sort(indicesOfTasks);
     }
 
 }

--- a/src/main/java/fan/cs2103t/duke/commons/Messages.java
+++ b/src/main/java/fan/cs2103t/duke/commons/Messages.java
@@ -5,8 +5,6 @@ package fan.cs2103t.duke.commons;
  */
 public class Messages {
 
-    public static final String MESSAGE_TASK_NOT_FOUND = "Oops, the task doesn't seem to exist.";
-    public static final String MESSAGE_TASK_ALREADY_DONE = "You have already done this task!";
     public static final String MESSAGE_NOTHING_MATCHING_QUERY = "It seems nothing in your list "
             + "matches the search query...";
     public static final String MESSAGE_EMPTY_TODO_DESCRIPTION = "OOPS!!! "
@@ -32,9 +30,11 @@ public class Messages {
 
     public static final String MESSAGE_SUCCESSFULLY_ADDED_FORMAT = "Got it. "
             + "I've added this task: \n  %s\nNow you have %d tasks in the list.";
-    public static final String MESSAGE_SUCCESSFULLY_DELETED_FORMAT = "Noted. "
-            + "I've removed this task: \n %s\nNow you have %d tasks in the list.";
-    public static final String MESSAGE_SUCCESSFULLY_DONE_FORMAT = "Nice! I've marked this task as done: \n %s";
+    public static final String MESSAGE_SUCCESSFULLY_DELETED_FORMAT = "Task %d: Noted. "
+            + "I've removed this task: \n %s\n";
+    public static final String MESSAGE_TASK_NOT_FOUND_FORMAT = "Task %d: Oops, the task doesn't seem to exist.\n";
+    public static final String MESSAGE_TASK_ALREADY_DONE_FORMAT = "Task %d: You have already done this task!\n";
+    public static final String MESSAGE_SUCCESSFULLY_DONE_FORMAT = "Task %d: Nice! I've marked this task as done: \n %s\n";
     public static final String MESSAGE_SUCCESSFULLY_FOUND_FORMAT = "Here are the matching tasks in your list: \n%s";
 
 }

--- a/src/main/java/fan/cs2103t/duke/parser/Parser.java
+++ b/src/main/java/fan/cs2103t/duke/parser/Parser.java
@@ -13,6 +13,7 @@ import static fan.cs2103t.duke.commons.Messages.MESSAGE_WRONG_DEADLINE_FORMAT;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 
 import fan.cs2103t.duke.command.AddCommand;
 import fan.cs2103t.duke.command.Command;
@@ -96,8 +97,9 @@ public class Parser {
             if (input.equals("done")) {
                 throw new DukeException(MESSAGE_EMPTY_DONE_COMMAND);
             }
-            if (input.charAt(4) == ' ' && isValidNum(input.substring(5))) {
-                return new DoneCommand(Integer.parseInt(input.substring(5).trim()));
+            ArrayList<Integer> numbers = areValidNumbers(input.substring(5));
+            if (input.charAt(4) == ' ' && numbers != null) {
+                return new DoneCommand(numbers);
             } else {
                 throw new DukeException(MESSAGE_INVALID_INPUT);
             }
@@ -105,8 +107,9 @@ public class Parser {
             if (input.equals("delete")) {
                 throw new DukeException(MESSAGE_EMPTY_DELETE_COMMAND);
             }
-            if (input.charAt(6) == ' ' && isValidNum(input.substring(7))) {
-                return new DeleteCommand(Integer.parseInt(input.substring(7).trim()));
+            ArrayList<Integer> numbers = areValidNumbers(input.substring(7));
+            if (input.charAt(6) == ' ' && numbers != null) {
+                return new DeleteCommand(numbers);
             } else {
                 throw new DukeException(MESSAGE_INVALID_INPUT);
             }
@@ -125,13 +128,28 @@ public class Parser {
         throw new DukeException(MESSAGE_INVALID_INPUT);
     }
 
-    private boolean isValidNum(String s) {
-        try {
-            Integer.parseInt(s.trim());
-        } catch (Exception e) {
-            return false;
+    private ArrayList<Integer> areValidNumbers(String s) {
+        String[] strings = s.trim().split("\\s+");
+        ArrayList<Integer> numbers = new ArrayList<>();
+        for (String string : strings) {
+            Integer i = isValidNum(string);
+            if (i == null) {
+                return null;
+            } else {
+                numbers.add(i);
+            }
         }
-        return true;
+        return numbers;
+    }
+
+    private Integer isValidNum(String s) {
+        int i;
+        try {
+            i = Integer.parseInt(s.trim());
+        } catch (Exception e) {
+            return null;
+        }
+        return i;
     }
 
     private Todo parseTodo(String s) throws DukeException {


### PR DESCRIPTION
"done" and "delete" commands only allow one number as their argument.

This makes it painful for users when they want to mark several tasks
as done or delete several tasks at one time.

Let's modify DoneCommand and DeleteCommand to allow multiple numbers
as arguments of "done" and "delete" commands. For example,
now users can key in "done 1 2 3 4" or "delete 1 2 3 4".